### PR TITLE
fix the bug

### DIFF
--- a/dbt-refresh-incremental/model_incremental_refresh.sh
+++ b/dbt-refresh-incremental/model_incremental_refresh.sh
@@ -218,7 +218,11 @@ git diff --name-status "$PREVIOUS_COMMIT" "$CURRENT_COMMIT" | \
   awk '{print $2}' > "$CHANGED_FILES_LIST" || true
 
 # Check if any files were found
-CHANGED_FILES_COUNT=$(grep -c . "$CHANGED_FILES_LIST" || echo "0")
+if [ -s "$CHANGED_FILES_LIST" ]; then
+  CHANGED_FILES_COUNT=$(wc -l < "$CHANGED_FILES_LIST")
+else
+  CHANGED_FILES_COUNT=0
+fi
 log "Detected $CHANGED_FILES_COUNT changed SQL files"
 
 # Create a JSON array of changed SQL files


### PR DESCRIPTION
What This Fixes
✅ Eliminates the "integer expression expected" errors on lines 227 and 254
✅ Properly handles the case when no SQL files are changed
✅ Ensures the early exit logic works correctly when CHANGED_FILES_COUNT is 0
✅ Maintains the same functionality for when files are actually changed
